### PR TITLE
Force US country code for full 6GHz band support in WLAN

### DIFF
--- a/drivers/misc/mediatek/connectivity/wlan/core/gen4m/os/linux/gl_vendor.c
+++ b/drivers/misc/mediatek/connectivity/wlan/core/gen4m/os/linux/gl_vendor.c
@@ -439,8 +439,9 @@ int mtk_cfg80211_vendor_set_country_code(struct wiphy
 	attr = (struct nlattr *)data;
 	if (attr->nla_type == WIFI_ATTRIBUTE_COUNTRY_CODE &&
 			nla_len(attr) >= 2) {
-		country[0] = *((uint8_t *)nla_data(attr));
-		country[1] = *((uint8_t *)nla_data(attr) + 1);
+		/* Force US: firmware regulatory DB has fullest band support */
+		country[0] = 'U';
+		country[1] = 'S';
 	}
 
 	DBGLOG(REQ, INFO, "Set country code: %c%c\n", country[0],

--- a/drivers/misc/mediatek/connectivity/wlan/core/gen4m/os/linux/gl_wext_priv.c
+++ b/drivers/misc/mediatek/connectivity/wlan/core/gen4m/os/linux/gl_wext_priv.c
@@ -9461,18 +9461,13 @@ int priv_driver_set_country(IN struct net_device *prNetDev,
 
 	if (regd_is_single_sku_en()) {
 		uint8_t aucCountry_code[4] = {0, 0, 0, 0};
-		uint8_t i, count;
 
-		/* command like "COUNTRY US", "COUNTRY US1" and
-		 * "COUNTRY US01"
-		 */
-		count = kalStrnLen(apcArgv[1], sizeof(aucCountry_code));
-		for (i = 0; i < count; i++)
-			aucCountry_code[i] = apcArgv[1][i];
-
+		/* Force US: firmware regulatory DB has fullest band support */
+		aucCountry_code[0] = 'U';
+		aucCountry_code[1] = 'S';
 
 		rStatus = kalIoctl(prGlueInfo, wlanoidSetCountryCode,
-				   &aucCountry_code[0], count,
+				   &aucCountry_code[0], 2,
 				   FALSE, FALSE, TRUE, &u4BufLen);
 		if (rStatus != WLAN_STATUS_SUCCESS)
 			return -1;
@@ -9482,8 +9477,9 @@ int priv_driver_set_country(IN struct net_device *prNetDev,
 
 
 	/* command like "COUNTRY US", "COUNTRY EU" and "COUNTRY JP" */
-	aucCountry[0] = apcArgv[1][0];
-	aucCountry[1] = apcArgv[1][1];
+	/* Force US: firmware regulatory DB has fullest band support */
+	aucCountry[0] = 'U';
+	aucCountry[1] = 'S';
 
 	rStatus = kalIoctl(prGlueInfo, wlanoidSetCountryCode,
 			   &aucCountry[0], 2, FALSE, FALSE, TRUE,


### PR DESCRIPTION
The only drawback with this approach is that 6 GHz appears grayed out initially. However, once Hotspot is enabled, the 6 GHz option becomes available, and if the previous hotspot state was 6 GHz, it's automatically selected. This is the most practical solution, as alternative approaches like props and overlay have not worked, and as kernel exists directly above the Wi-Fi driver this change works on the lowest level possible by us